### PR TITLE
New storage api

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,6 +14,7 @@
 * Chris Gianelloni <wolf31o2@gmail.com>
 * Dan Prince <dprince@redhat.com>
 * Daniel Broudy <broudy@google.com>
+* Dean Putney <dean@glowforge.com>
 * Doug Henderson <dhenderson@maestrodev.com>
 * Eric Johnson <erjohnso@google.com>
 * Ferran Rodenas <frodenas@gmail.com>

--- a/examples/storage_json.rb
+++ b/examples/storage_json.rb
@@ -15,7 +15,7 @@ def test
 
   puts "Put a bucket..."
   puts "----------------"
-  connection.put_bucket("fog-smoke-test", options = { "x-goog-acl" => "publicReadWrite" })
+  connection.put_bucket("fog-smoke-test", options = { "predefinedAcl" => "publicReadWrite" })
 
   puts "Get the bucket..."
   puts "-----------------"

--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
 
   # TODO: Upgrade to 0.9, which is not compatible.
   spec.add_development_dependency "google-api-client", "< 0.9", ">= 0.6.2"
-  spec.add_development_dependency "httpclient"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "shindo"
   spec.add_development_dependency "minitest"

--- a/lib/fog/google.rb
+++ b/lib/fog/google.rb
@@ -88,13 +88,6 @@ module Fog
         # NOTE: loaded here to avoid requiring this as a core Fog dependency
         begin
           require "google/api_client"
-
-          # Use httpclient to avoid broken pipe errors with large uploads
-          Faraday.default_adapter = :httpclient
-
-          # Only add the following statement if using Faraday >= 0.9.2
-          # Override gzip middleware with no-op for httpclient
-          Faraday::Response.register_middleware :gzip => Faraday::Response::Middleware
         rescue LoadError => error
           Fog::Logger.warning("Please install the google-api-client gem before using this provider")
           raise error

--- a/lib/fog/google/models/storage_json/directories.rb
+++ b/lib/fog/google/models/storage_json/directories.rb
@@ -11,8 +11,22 @@ module Fog
           # TODO: Write
         end
 
-        def get(_key, _options = {})
-          # TODO: Write
+        def get(key, options = {})
+          remap_attributes(options,             :delimiter  => "delimiter",
+                                                :marker     => "marker",
+                                                :max_keys   => "max-keys",
+                                                :prefix     => "prefix")
+          data = service.get_bucket(key, options).body
+          directory = new(:key => data["name"])
+          # options = {}
+          # for k, v in data
+          #   if %w(commonPrefixes delimiter IsTruncated Marker MaxKeys Prefix).include?(k)
+          #     options[k] = v
+          #   end
+          # end
+          # directory.files.merge_attributes(options)
+          # directory.files.load(data["contents"])
+          directory
         rescue Excon::Errors::NotFound
           nil
         end

--- a/lib/fog/google/models/storage_json/directory.rb
+++ b/lib/fog/google/models/storage_json/directory.rb
@@ -8,7 +8,7 @@ module Fog
         identity :key, :aliases => %w(Name name)
 
         def acl=(new_acl)
-          valid_acls = ["private", "public-read", "public-read-write", "authenticated-read"]
+          valid_acls = ["private", "projectPrivate", "publicRead", "publicReadWrite", "authenticatedRead"]
           unless valid_acls.include?(new_acl)
             raise ArgumentError.new("acl must be one of [#{valid_acls.join(', ')}]")
           end
@@ -34,7 +34,7 @@ module Fog
 
         def public=(new_public)
           if new_public
-            @acl = "public-read"
+            @acl = "publicRead"
           else
             @acl = "private"
           end
@@ -43,7 +43,9 @@ module Fog
 
         def public_url
           requires :key
-          if service.get_bucket_acl(key).body["AccessControlList"].detect { |entry| entry["Scope"]["type"] == "AllUsers" && entry["Permission"] == "READ" }
+          acl = service.get_bucket_acl(key).body
+          pp acl
+          if acl["items"].detect { |entry| entry["entity"] == "allUsers" && entry["role"] == "READER" }
             if key.to_s =~ /^(?:[a-z]|\d(?!\d{0,2}(?:\.\d{1,3}){3}$))(?:[a-z0-9]|\.(?![\.\-])|\-(?![\.])){1,61}[a-z0-9]$/
               "https://#{key}.storage.googleapis.com"
             else
@@ -54,7 +56,12 @@ module Fog
 
         def save
           requires :key
-          # TODO: Write.
+          options = {}
+          options["predefinedAcl"] = @acl if @acl
+          options["LocationConstraint"] = @location if @location
+          options["StorageClass"] = attributes[:storage_class] if attributes[:storage_class]
+          service.put_bucket(key, options)
+          true
         end
       end
     end

--- a/lib/fog/google/models/storage_json/directory.rb
+++ b/lib/fog/google/models/storage_json/directory.rb
@@ -44,7 +44,6 @@ module Fog
         def public_url
           requires :key
           acl = service.get_bucket_acl(key).body
-          pp acl
           if acl["items"].detect { |entry| entry["entity"] == "allUsers" && entry["role"] == "READER" }
             if key.to_s =~ /^(?:[a-z]|\d(?!\d{0,2}(?:\.\d{1,3}){3}$))(?:[a-z0-9]|\.(?![\.\-])|\-(?![\.])){1,61}[a-z0-9]$/
               "https://#{key}.storage.googleapis.com"

--- a/lib/fog/google/models/storage_json/file.rb
+++ b/lib/fog/google/models/storage_json/file.rb
@@ -22,7 +22,7 @@ module Fog
 
         # TODO: Verify
         def acl=(new_acl)
-          valid_acls = ["private", "public-read", "public-read-write", "authenticated-read"]
+          valid_acls = ["private", "projectPrivate", "bucketOwnerFullControl", "bucketOwnerRead", "authenticatedRead", "publicRead"]
           unless valid_acls.include?(new_acl)
             raise ArgumentError.new("acl must be one of [#{valid_acls.join(', ')}]")
           end
@@ -85,7 +85,7 @@ module Fog
         # TODO: Verify
         def public=(new_public)
           if new_public
-            @acl = "public-read"
+            @acl = "publicRead"
           else
             @acl = "private"
           end
@@ -116,7 +116,7 @@ module Fog
           if options != {}
             Fog::Logger.deprecation("options param is deprecated, use acl= instead [light_black](#{caller.first})[/]")
           end
-          options["x-goog-acl"] ||= @acl if @acl
+          options["predefinedAcl"] ||= @acl if @acl
           options["Cache-Control"] = cache_control if cache_control
           options["Content-Disposition"] = content_disposition if content_disposition
           options["Content-Encoding"] = content_encoding if content_encoding

--- a/lib/fog/google/models/storage_json/files.rb
+++ b/lib/fog/google/models/storage_json/files.rb
@@ -1,0 +1,98 @@
+require "fog/core/collection"
+require "fog/google/models/storage_json/file"
+
+module Fog
+  module Google
+    class StorageJSON
+      class Files < Fog::Collection
+        extend Fog::Deprecation
+        deprecate :get_url, :get_https_url
+
+        attribute :common_prefixes, :aliases => "CommonPrefixes"
+        attribute :delimiter,       :aliases => "Delimiter"
+        attribute :directory
+        attribute :is_truncated,    :aliases => "IsTruncated"
+        attribute :marker,          :aliases => "Marker"
+        attribute :max_keys,        :aliases => ["MaxKeys", "max-keys"]
+        attribute :prefix,          :aliases => "Prefix"
+
+        model Fog::Google::StorageJSON::File
+
+        def all(options = {})
+          requires :directory
+          options = {
+            "delimiter"   => delimiter,
+            "marker"      => marker,
+            "max-keys"    => max_keys,
+            "prefix"      => prefix
+          }.merge!(options)
+          options = options.reject { |_key, value| value.nil? || value.to_s.empty? }
+          merge_attributes(options)
+          parent = directory.collection.get(
+            directory.key,
+            options
+          )
+          if parent
+            merge_attributes(parent.files.attributes)
+            load(parent.files.map(&:attributes))
+          end
+        end
+
+        alias_method :each_file_this_page, :each
+        def each
+          if !block_given?
+            self
+          else
+            subset = dup.all
+
+            subset.each_file_this_page { |f| yield f }
+            while subset.is_truncated
+              subset = subset.all(:marker => subset.last.key)
+              subset.each_file_this_page { |f| yield f }
+            end
+
+            self
+          end
+        end
+
+        def get(key, options = {}, &block)
+          requires :directory
+          data = service.get_object(directory.key, key, options, &block)
+          file_data = {}
+          data.headers.each do |key, value|
+            file_data[key] = value
+          end
+          file_data.merge!(:body => data.body,
+                           :key  => key)
+          new(file_data)
+        rescue Excon::Errors::NotFound
+          nil
+        end
+
+        def get_http_url(key, expires)
+          requires :directory
+          service.get_object_http_url(directory.key, key, expires)
+        end
+
+        def get_https_url(key, expires)
+          requires :directory
+          service.get_object_https_url(directory.key, key, expires)
+        end
+
+        def head(key, options = {})
+          requires :directory
+          data = service.head_object(directory.key, key, options)
+          file_data = data.headers.merge(:key => key)
+          new(file_data)
+        rescue Excon::Errors::NotFound
+          nil
+        end
+
+        def new(attributes = {})
+          requires :directory
+          super({ :directory => directory }.merge(attributes))
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/requests/storage_json/copy_object.rb
+++ b/lib/fog/google/requests/storage_json/copy_object.rb
@@ -25,38 +25,41 @@ module Fog
         #     * 'LastModified'<~Time> - date object was last modified
         #
         def copy_object(source_bucket_name, source_object_name, target_bucket_name, target_object_name, options = {})
-          # headers = { "x-goog-copy-source" => "/#{source_bucket_name}/#{source_object_name}" }.merge(options)
-          # request(:expects  => 200,
-          #         :headers  => headers,
-          #         :host     => "#{target_bucket_name}.#{@host}",
-          #         :method   => "PUT",
-          #         :parser   => Fog::Parsers::Storage::Google::CopyObject.new,
-          #         :path     => Fog::Google.escape(target_object_name))
+          api_method = @storage_json.objects.copy
+          parameters = {
+            "sourceBucket" => source_bucket_name,
+            "sourceObject" => source_object_name,
+            "destinationBucket" => target_bucket_name,
+            "destinationObject" => target_object_name
+          }
+          parameters.merge! options
+
+          request(api_method, parameters)
         end
       end
 
       class Mock
         def copy_object(source_bucket_name, source_object_name, target_bucket_name, target_object_name, _options = {})
-          # response = Excon::Response.new
-          # source_bucket = data[:buckets][source_bucket_name]
-          # source_object = source_bucket && source_bucket[:objects][source_object_name]
-          # target_bucket = data[:buckets][target_bucket_name]
+          response = Excon::Response.new
+          source_bucket = data[:buckets][source_bucket_name]
+          source_object = source_bucket && source_bucket[:objects][source_object_name]
+          target_bucket = data[:buckets][target_bucket_name]
 
-          # if source_object && target_bucket
-          #   response.status = 200
-          #   target_object = source_object.dup
-          #   target_object.merge!("Name" => target_object_name)
-          #   target_bucket[:objects][target_object_name] = target_object
-          #   response.body = {
-          #     "ETag"          => target_object["ETag"],
-          #     "LastModified"  => Time.parse(target_object["Last-Modified"])
-          #   }
-          # else
-          #   response.status = 404
-          #   raise(Excon::Errors.status_error({ :expects => 200 }, response))
-          # end
+          if source_object && target_bucket
+            response.status = 200
+            target_object = source_object.dup
+            target_object.merge!("Name" => target_object_name)
+            target_bucket[:objects][target_object_name] = target_object
+            response.body = {
+              "ETag"          => target_object["ETag"],
+              "LastModified"  => Time.parse(target_object["Last-Modified"])
+            }
+          else
+            response.status = 404
+            raise(Excon::Errors.status_error({ :expects => 200 }, response))
+          end
 
-          # response
+          response
         end
       end
     end

--- a/lib/fog/google/requests/storage_json/get_bucket_acl.rb
+++ b/lib/fog/google/requests/storage_json/get_bucket_acl.rb
@@ -26,7 +26,14 @@ module Fog
         #           * 'Permission'<~String> - Permission, in [FULL_CONTROL, WRITE, WRITE_ACP, READ, READ_ACP]
         #
         def get_bucket_acl(bucket_name)
-          # raise ArgumentError.new("bucket_name is required") unless bucket_name
+          raise ArgumentError.new("bucket_name is required") unless bucket_name
+
+          api_method = @storage_json.bucket_access_controls.list
+          parameters = {
+            "bucket" => bucket_name
+          }
+
+          request(api_method, parameters)
           # request(:expects    => 200,
           #         :headers    => {},
           #         :host       => "#{bucket_name}.#{@host}",
@@ -39,15 +46,15 @@ module Fog
 
       class Mock
         def get_bucket_acl(bucket_name)
-          # response = Excon::Response.new
-          # if acl = data[:acls][:bucket][bucket_name]
-          #   response.status = 200
-          #   response.body = acl
-          # else
-          #   response.status = 404
-          #   raise(Excon::Errors.status_error({ :expects => 200 }, response))
-          # end
-          # response
+          response = Excon::Response.new
+          if acl = data[:acls][:bucket][bucket_name]
+            response.status = 200
+            response.body = acl
+          else
+            response.status = 404
+            raise(Excon::Errors.status_error({ :expects => 200 }, response))
+          end
+          response
         end
       end
     end

--- a/lib/fog/google/requests/storage_json/get_object.rb
+++ b/lib/fog/google/requests/storage_json/get_object.rb
@@ -25,8 +25,16 @@ module Fog
         #     * 'Last-Modified'<~String> - Last modified timestamp for object
         #
         def get_object(bucket_name, object_name, options = {}, &_block)
-          # raise ArgumentError.new("bucket_name is required") unless bucket_name
-          # raise ArgumentError.new("object_name is required") unless object_name
+          raise ArgumentError.new("bucket_name is required") unless bucket_name
+          raise ArgumentError.new("object_name is required") unless object_name
+
+          api_method = @storage_json.buckets.get
+          parameters = {
+            "bucket" => bucket_name,
+            "object" => object_name
+          }
+
+          request(api_method, parameters)
 
           # params = { :headers => {} }
           # if version_id = options.delete("versionId")

--- a/lib/fog/google/requests/storage_json/get_object.rb
+++ b/lib/fog/google/requests/storage_json/get_object.rb
@@ -24,7 +24,7 @@ module Fog
         #     * 'ETag'<~String> - Etag of object
         #     * 'Last-Modified'<~String> - Last modified timestamp for object
         #
-        def get_object(bucket_name, object_name, options = {}, &_block)
+        def get_object(bucket_name, object_name, _options = {}, &_block)
           raise ArgumentError.new("bucket_name is required") unless bucket_name
           raise ArgumentError.new("object_name is required") unless object_name
 

--- a/lib/fog/google/requests/storage_json/get_object_acl.rb
+++ b/lib/fog/google/requests/storage_json/get_object_acl.rb
@@ -29,8 +29,17 @@ module Fog
         #           * 'Permission'<~String> - Permission, in [FULL_CONTROL, WRITE, WRITE_ACP, READ, READ_ACP]
         #
         def get_object_acl(bucket_name, object_name, options = {})
-          # raise ArgumentError.new("bucket_name is required") unless bucket_name
-          # raise ArgumentError.new("object_name is required") unless object_name
+          raise ArgumentError.new("bucket_name is required") unless bucket_name
+          raise ArgumentError.new("object_name is required") unless object_name
+
+          api_method = @storage_json.object_access_controls.list
+          parameters = {
+            "bucket" => bucket_name,
+            "object" => object_name
+          }
+
+          request(api_method, parameters)
+
           # query = { "acl" => nil }
           # if version_id = options.delete("versionId")
           #   query["versionId"] = version_id

--- a/lib/fog/google/requests/storage_json/get_object_acl.rb
+++ b/lib/fog/google/requests/storage_json/get_object_acl.rb
@@ -28,7 +28,7 @@ module Fog
         #              * 'URI'<~String> - URI of group to grant access for
         #           * 'Permission'<~String> - Permission, in [FULL_CONTROL, WRITE, WRITE_ACP, READ, READ_ACP]
         #
-        def get_object_acl(bucket_name, object_name, options = {})
+        def get_object_acl(bucket_name, object_name, _options = {})
           raise ArgumentError.new("bucket_name is required") unless bucket_name
           raise ArgumentError.new("object_name is required") unless object_name
 

--- a/lib/fog/google/requests/storage_json/get_object_https_url.rb
+++ b/lib/fog/google/requests/storage_json/get_object_https_url.rb
@@ -14,7 +14,7 @@ module Fog
           }
 
           response = request(api_method, parameters)
-          response.body["selfLink"]
+          response.body["mediaLink"]
           # https_url({
           #             :headers  => {},
           #             :host     => @host,

--- a/lib/fog/google/requests/storage_json/get_object_https_url.rb
+++ b/lib/fog/google/requests/storage_json/get_object_https_url.rb
@@ -2,7 +2,7 @@ module Fog
   module Google
     class StorageJSON
       module GetObjectHttpsUrl
-        # Formerly included "expires", but no doesn't seem to exist anymore? 
+        # Formerly included "expires", but no doesn't seem to exist anymore?
         def get_object_https_url(bucket_name, object_name)
           raise ArgumentError.new("bucket_name is required") unless bucket_name
           raise ArgumentError.new("object_name is required") unless object_name

--- a/lib/fog/google/requests/storage_json/get_object_https_url.rb
+++ b/lib/fog/google/requests/storage_json/get_object_https_url.rb
@@ -2,9 +2,19 @@ module Fog
   module Google
     class StorageJSON
       module GetObjectHttpsUrl
-        def get_object_https_url(bucket_name, object_name, expires)
-          # raise ArgumentError.new("bucket_name is required") unless bucket_name
-          # raise ArgumentError.new("object_name is required") unless object_name
+        # Formerly included "expires", but no doesn't seem to exist anymore? 
+        def get_object_https_url(bucket_name, object_name)
+          raise ArgumentError.new("bucket_name is required") unless bucket_name
+          raise ArgumentError.new("object_name is required") unless object_name
+
+          api_method = @storage_json.objects.get
+          parameters = {
+            "bucket" => bucket_name,
+            "object" => object_name
+          }
+
+          response = request(api_method, parameters)
+          response.body["selfLink"]
           # https_url({
           #             :headers  => {},
           #             :host     => @host,

--- a/lib/fog/google/requests/storage_json/put_bucket.rb
+++ b/lib/fog/google/requests/storage_json/put_bucket.rb
@@ -14,8 +14,7 @@ module Fog
         # * response<~Excon::Response>:
         #   * status<~Integer> - 200
         def put_bucket(bucket_name, options = {})
-          acl = options["x-goog-acl"] if options["x-goog-acl"]
-          location = options["LocationConstraint"] || nil
+          location = options["LocationConstraint"] if options["LocationConstraint"]
 
           api_method = @storage_json.buckets.insert
           parameters = {
@@ -26,7 +25,7 @@ module Fog
             name: bucket_name,
             location: location
           }
-          body_object.merge! options
+          parameters.merge! options
 
           request(api_method, parameters, body_object = body_object)
         end

--- a/lib/fog/google/requests/storage_json/put_bucket.rb
+++ b/lib/fog/google/requests/storage_json/put_bucket.rb
@@ -14,20 +14,19 @@ module Fog
         # * response<~Excon::Response>:
         #   * status<~Integer> - 200
         def put_bucket(bucket_name, options = {})
-          acl = options["x-goog-acl"] || "private"
+          acl = options["x-goog-acl"] if options["x-goog-acl"]
           location = options["LocationConstraint"] || nil
 
           api_method = @storage_json.buckets.insert
           parameters = {
             "project" => @project,
-            "predefinedAcl" => acl,
-            "predefinedObjectAcl" => acl,
             "projection" => "full"
           }
           body_object = {
-            :name => bucket_name,
-            :location => location
+            name: bucket_name,
+            location: location
           }
+          body_object.merge! options
 
           request(api_method, parameters, body_object = body_object)
         end

--- a/lib/fog/google/requests/storage_json/put_bucket_acl.rb
+++ b/lib/fog/google/requests/storage_json/put_bucket_acl.rb
@@ -10,6 +10,16 @@ module Fog
       class Real
         # Change access control list for an Google Storage bucket
         def put_bucket_acl(bucket_name, acl)
+          raise ArgumentError.new("bucket_name is required") unless bucket_name
+          raise ArgumentError.new("acl is required") unless acl
+
+          api_method = @storage_json.bucket_access_controls.insert
+          parameters = {
+            "bucket" => bucket_name
+          }
+          body_object = acl
+
+          request(api_method, parameters, body_object = body_object)
           #           data = <<-DATA
           # <AccessControlList>
           #   <Owner>

--- a/lib/fog/google/requests/storage_json/put_object.rb
+++ b/lib/fog/google/requests/storage_json/put_object.rb
@@ -22,7 +22,7 @@ module Fog
         # * response<~Excon::Response>:
         #   * headers<~Hash>:
         #     * 'ETag'<~String> - etag of new object
-        def put_object(bucket_name, object_name, data, _options = {})
+        def put_object(bucket_name, object_name, data, options = {})
           if data.is_a? String
             data = StringIO.new(data)
             mime_type = "text/plain"
@@ -37,6 +37,8 @@ module Fog
             "bucket" => bucket_name,
             "name" => object_name
           }
+          parameters.merge! options
+          
           body_object = {
             contentType: mime_type
           }

--- a/lib/fog/google/requests/storage_json/put_object.rb
+++ b/lib/fog/google/requests/storage_json/put_object.rb
@@ -38,7 +38,7 @@ module Fog
             "name" => object_name
           }
           body_object = {
-            :contentType => mime_type
+            contentType: mime_type
           }
 
           request(api_method, parameters, body_object = body_object, media = media)

--- a/lib/fog/google/requests/storage_json/put_object.rb
+++ b/lib/fog/google/requests/storage_json/put_object.rb
@@ -33,7 +33,7 @@ module Fog
           media = ::Google::APIClient::UploadIO.new(data, mime_type, object_name)
           api_method = @storage_json.objects.insert
           parameters = {
-            "uploadType" => "resumable",
+            "uploadType" => "multipart",
             "bucket" => bucket_name,
             "name" => object_name
           }

--- a/lib/fog/google/requests/storage_json/put_object_acl.rb
+++ b/lib/fog/google/requests/storage_json/put_object_acl.rb
@@ -35,25 +35,25 @@ module Fog
           }
           body_object = acl
 
-          request(api_method, parameters, body_object=body_object)
-#           data = <<-DATA
-# <AccessControlList>
-#   <Owner>
-#     #{tag('ID', acl['Owner']['ID'])}
-#   </Owner>
-#   <Entries>
-#     #{entries_list(acl['AccessControlList'])}
-#   </Entries>
-# </AccessControlList>
-# DATA
+          request(api_method, parameters, body_object = body_object)
+          #           data = <<-DATA
+          # <AccessControlList>
+          #   <Owner>
+          #     #{tag('ID', acl['Owner']['ID'])}
+          #   </Owner>
+          #   <Entries>
+          #     #{entries_list(acl['AccessControlList'])}
+          #   </Entries>
+          # </AccessControlList>
+          # DATA
 
-#           request(:body     => data,
-#                   :expects  => 200,
-#                   :headers  => {},
-#                   :host     => "#{bucket_name}.#{@host}",
-#                   :method   => "PUT",
-#                   :query    => { "acl" => nil },
-#                   :path     => CGI.escape(object_name))
+          #           request(:body     => data,
+          #                   :expects  => 200,
+          #                   :headers  => {},
+          #                   :host     => "#{bucket_name}.#{@host}",
+          #                   :method   => "PUT",
+          #                   :query    => { "acl" => nil },
+          #                   :path     => CGI.escape(object_name))
         end
       end
     end

--- a/lib/fog/google/requests/storage_json/put_object_acl.rb
+++ b/lib/fog/google/requests/storage_json/put_object_acl.rb
@@ -24,24 +24,36 @@ module Fog
         end
 
         def put_object_acl(bucket_name, object_name, acl)
-          #           data = <<-DATA
-          # <AccessControlList>
-          #   <Owner>
-          #     #{tag('ID', acl['Owner']['ID'])}
-          #   </Owner>
-          #   <Entries>
-          #     #{entries_list(acl['AccessControlList'])}
-          #   </Entries>
-          # </AccessControlList>
-          # DATA
+          raise ArgumentError.new("bucket_name is required") unless bucket_name
+          raise ArgumentError.new("object_name is required") unless object_name
+          raise ArgumentError.new("acl is required") unless acl
 
-          #           request(:body     => data,
-          #                   :expects  => 200,
-          #                   :headers  => {},
-          #                   :host     => "#{bucket_name}.#{@host}",
-          #                   :method   => "PUT",
-          #                   :query    => { "acl" => nil },
-          #                   :path     => CGI.escape(object_name))
+          api_method = @storage_json.object_access_controls.insert
+          parameters = {
+            "bucket" => bucket_name,
+            "object" => object_name
+          }
+          body_object = acl
+
+          request(api_method, parameters, body_object=body_object)
+#           data = <<-DATA
+# <AccessControlList>
+#   <Owner>
+#     #{tag('ID', acl['Owner']['ID'])}
+#   </Owner>
+#   <Entries>
+#     #{entries_list(acl['AccessControlList'])}
+#   </Entries>
+# </AccessControlList>
+# DATA
+
+#           request(:body     => data,
+#                   :expects  => 200,
+#                   :headers  => {},
+#                   :host     => "#{bucket_name}.#{@host}",
+#                   :method   => "PUT",
+#                   :query    => { "acl" => nil },
+#                   :path     => CGI.escape(object_name))
         end
       end
     end

--- a/lib/fog/google/requests/storage_json/put_object_url.rb
+++ b/lib/fog/google/requests/storage_json/put_object_url.rb
@@ -13,9 +13,19 @@ module Fog
         # * response<~Excon::Response>:
         #   * body<~String> - url for object
         #
-        def put_object_url(bucket_name, object_name, expires, headers = {})
-          # raise ArgumentError.new("bucket_name is required") unless bucket_name
-          # raise ArgumentError.new("object_name is required") unless object_name
+        def put_object_url(bucket_name, object_name, headers = {})
+          raise ArgumentError.new("bucket_name is required") unless bucket_name
+          raise ArgumentError.new("object_name is required") unless object_name
+
+          api_method = @storage_json.objects.insert
+          parameters = {
+            "uploadType" => "resumable",
+            "bucket" => bucket_name,
+            "name" => object_name
+          }
+
+
+          request(api_method, parameters)
           # https_url({
           #             :headers  => headers,
           #             :host     => @host,

--- a/lib/fog/google/requests/storage_json/put_object_url.rb
+++ b/lib/fog/google/requests/storage_json/put_object_url.rb
@@ -13,7 +13,7 @@ module Fog
         # * response<~Excon::Response>:
         #   * body<~String> - url for object
         #
-        def put_object_url(bucket_name, object_name, headers = {})
+        def put_object_url(bucket_name, object_name, _headers = {})
           raise ArgumentError.new("bucket_name is required") unless bucket_name
           raise ArgumentError.new("object_name is required") unless object_name
 
@@ -23,7 +23,6 @@ module Fog
             "bucket" => bucket_name,
             "name" => object_name
           }
-
 
           request(api_method, parameters)
           # https_url({

--- a/lib/fog/google/storage_json.rb
+++ b/lib/fog/google/storage_json.rb
@@ -16,6 +16,10 @@ module Fog
       ##
       # Models
       model_path "fog/google/models/storage_json"
+      collection :directories
+      model :directory
+      collection :files
+      model :file
 
       ##
       # Requests

--- a/lib/fog/google/storage_json.rb
+++ b/lib/fog/google/storage_json.rb
@@ -20,12 +20,12 @@ module Fog
       ##
       # Requests
       request_path "fog/google/requests/storage_json"
-      # request :copy_object
+      request :copy_object
       request :delete_bucket
       request :delete_object
       request :get_bucket
-      # request :get_bucket_acl
-      # request :get_object
+      request :get_bucket_acl
+      request :get_object
       # request :get_object_acl
       # request :get_object_torrent
       # request :get_object_http_url
@@ -34,10 +34,10 @@ module Fog
       # request :get_service
       # request :head_object
       request :put_bucket
-      # request :put_bucket_acl
+      request :put_bucket_acl
       request :put_object
       request :put_object_acl
-      # request :put_object_url
+      request :put_object_url
 
       class Mock
         include Fog::Google::Shared

--- a/lib/fog/google/storage_json.rb
+++ b/lib/fog/google/storage_json.rb
@@ -26,7 +26,7 @@ module Fog
       request :get_bucket
       request :get_bucket_acl
       request :get_object
-      # request :get_object_acl
+      request :get_object_acl
       # request :get_object_torrent
       # request :get_object_http_url
       request :get_object_https_url

--- a/lib/fog/google/storage_json.rb
+++ b/lib/fog/google/storage_json.rb
@@ -29,8 +29,8 @@ module Fog
       # request :get_object_acl
       # request :get_object_torrent
       # request :get_object_http_url
-      # request :get_object_https_url
-      # request :get_object_url
+      request :get_object_https_url
+      request :get_object_url
       # request :get_service
       # request :head_object
       request :put_bucket

--- a/lib/fog/google/storage_json.rb
+++ b/lib/fog/google/storage_json.rb
@@ -36,7 +36,7 @@ module Fog
       request :put_bucket
       # request :put_bucket_acl
       request :put_object
-      # request :put_object_acl
+      request :put_object_acl
       # request :put_object_url
 
       class Mock

--- a/test/integration/storage/test_buckets.rb
+++ b/test/integration/storage/test_buckets.rb
@@ -2,9 +2,6 @@ require "helpers/integration_test_helper"
 
 class TestBuckets < FogIntegrationTest
   def setup
-    # Uncomment this if you want to make real requests to GCE (you _will_ be billed!)
-    # WebMock.disable!
-
     @connection = Fog::Google::StorageJSON.new
   end
 

--- a/test/integration/storage/test_buckets.rb
+++ b/test/integration/storage/test_buckets.rb
@@ -6,10 +6,8 @@ class TestBuckets < FogIntegrationTest
   end
 
   def teardown
-    begin
-      @connection.delete_bucket("fog-smoke-test")
-    rescue
-    end
+    @connection.delete_bucket("fog-smoke-test")
+  rescue
   end
 
   def test_put_bucket
@@ -18,10 +16,10 @@ class TestBuckets < FogIntegrationTest
   end
 
   def test_put_bucket_acl
-    response = @connection.put_bucket("fog-smoke-test", options={ 'x-goog-acl' => 'publicReadWrite' })
+    response = @connection.put_bucket("fog-smoke-test", options = { "x-goog-acl" => "publicReadWrite" })
     assert_equal response.status, 200
-    acl = { entity: 'domain-example.com',
-            role: 'READER' }
+    acl = { entity: "domain-example.com",
+            role: "READER" }
     response = @connection.put_bucket_acl("fog-smoke-test", acl)
     assert_equal response.status, 200
   end
@@ -42,8 +40,8 @@ class TestBuckets < FogIntegrationTest
 
   def test_get_bucket_acl
     client_email = Fog.credentials[:google_client_email]
-    response = @connection.put_bucket("fog-smoke-test", 
-      options={ 'acl' => [{ entity: 'user-'+client_email, role: 'OWNER' }] })
+    response = @connection.put_bucket("fog-smoke-test",
+                                      options = { "acl" => [{ entity: "user-" + client_email, role: "OWNER" }] })
     assert_equal response.status, 200
     response = @connection.get_bucket_acl("fog-smoke-test")
     assert_equal response.status, 200

--- a/test/integration/storage/test_buckets.rb
+++ b/test/integration/storage/test_buckets.rb
@@ -1,0 +1,46 @@
+require "helpers/integration_test_helper"
+
+class TestBuckets < FogIntegrationTest
+  def setup
+    # Uncomment this if you want to make real requests to GCE (you _will_ be billed!)
+    # WebMock.disable!
+
+    @connection = Fog::Google::StorageJSON.new
+    # @subject = Fog::Compute[:google].target_instances
+    # @factory = TargetInstancesFactory.new(namespaced_name)
+  end
+
+  def teardown
+    begin
+      @connection.delete_bucket("fog-smoke-test")
+    rescue
+    end
+  end
+
+  def test_put_bucket
+    response = @connection.put_bucket("fog-smoke-test", options={ 'x-goog-acl' => 'publicReadWrite' })
+    assert_equal response.status, 200
+  end
+
+  def test_put_bucket_acl
+    skip
+  end
+
+  def test_delete_bucket
+    response = @connection.put_bucket("fog-smoke-test", options={ 'x-goog-acl' => 'publicReadWrite' })
+    assert_equal response.status, 200
+    response = @connection.delete_bucket("fog-smoke-test")
+    assert_equal response.status, 204
+  end
+
+  def test_get_bucket
+    response = @connection.put_bucket("fog-smoke-test", options={ 'x-goog-acl' => 'publicReadWrite' })
+    assert_equal response.status, 200
+    response = @connection.get_bucket("fog-smoke-test")
+    assert_equal response.status, 200
+  end
+
+  def test_get_bucket_acl
+    skip
+  end
+end

--- a/test/integration/storage/test_buckets.rb
+++ b/test/integration/storage/test_buckets.rb
@@ -16,9 +16,9 @@ class TestBuckets < FogIntegrationTest
   end
 
   def test_put_bucket_acl
-    response = @connection.put_bucket("fog-smoke-test", options = { "x-goog-acl" => "publicReadWrite" })
+    response = @connection.put_bucket("fog-smoke-test")
     assert_equal response.status, 200
-    acl = { entity: "domain-example.com",
+    acl = { entity: "domain-google.com",
             role: "READER" }
     response = @connection.put_bucket_acl("fog-smoke-test", acl)
     assert_equal response.status, 200

--- a/test/integration/storage/test_buckets.rb
+++ b/test/integration/storage/test_buckets.rb
@@ -6,8 +6,6 @@ class TestBuckets < FogIntegrationTest
     # WebMock.disable!
 
     @connection = Fog::Google::StorageJSON.new
-    # @subject = Fog::Compute[:google].target_instances
-    # @factory = TargetInstancesFactory.new(namespaced_name)
   end
 
   def teardown
@@ -18,29 +16,40 @@ class TestBuckets < FogIntegrationTest
   end
 
   def test_put_bucket
-    response = @connection.put_bucket("fog-smoke-test", options={ 'x-goog-acl' => 'publicReadWrite' })
+    response = @connection.put_bucket("fog-smoke-test")
     assert_equal response.status, 200
   end
 
   def test_put_bucket_acl
-    skip
+    puts "test_put_bucket_acl"
+    response = @connection.put_bucket("fog-smoke-test", options={ 'x-goog-acl' => 'publicReadWrite' })
+    assert_equal response.status, 200
+    acl = { entity: 'domain-example.com',
+            role: 'READER' }
+    response = @connection.put_bucket_acl("fog-smoke-test", acl)
+    assert_equal response.status, 200
   end
 
   def test_delete_bucket
-    response = @connection.put_bucket("fog-smoke-test", options={ 'x-goog-acl' => 'publicReadWrite' })
+    response = @connection.put_bucket("fog-smoke-test")
     assert_equal response.status, 200
     response = @connection.delete_bucket("fog-smoke-test")
     assert_equal response.status, 204
   end
 
   def test_get_bucket
-    response = @connection.put_bucket("fog-smoke-test", options={ 'x-goog-acl' => 'publicReadWrite' })
+    response = @connection.put_bucket("fog-smoke-test")
     assert_equal response.status, 200
     response = @connection.get_bucket("fog-smoke-test")
     assert_equal response.status, 200
   end
 
   def test_get_bucket_acl
-    skip
+    client_email = Fog.credentials[:google_client_email]
+    response = @connection.put_bucket("fog-smoke-test", 
+      options={ 'acl' => [{ entity: 'user-'+client_email, role: 'OWNER' }] })
+    assert_equal response.status, 200
+    response = @connection.get_bucket_acl("fog-smoke-test")
+    assert_equal response.status, 200
   end
 end

--- a/test/integration/storage/test_buckets.rb
+++ b/test/integration/storage/test_buckets.rb
@@ -18,7 +18,6 @@ class TestBuckets < FogIntegrationTest
   end
 
   def test_put_bucket_acl
-    puts "test_put_bucket_acl"
     response = @connection.put_bucket("fog-smoke-test", options={ 'x-goog-acl' => 'publicReadWrite' })
     assert_equal response.status, 200
     acl = { entity: 'domain-example.com',

--- a/test/integration/storage/test_directories.rb
+++ b/test/integration/storage/test_directories.rb
@@ -25,6 +25,10 @@ class TestBuckets < FogIntegrationTest
     @directory = @@directory
   end
 
+  def test_all_directories
+    skip
+  end
+
   def test_get_directory
     directory_get = @connection.directories.get("fog-smoke-test")
     assert_instance_of Fog::Google::StorageJSON::Directory, directory_get
@@ -36,9 +40,21 @@ class TestBuckets < FogIntegrationTest
     assert directory_create.destroy
   end
 
-  def test_public_url_directory
+  def test_public_url
     public_url = @directory.public_url
     assert_match /storage\.googleapis\.com/, public_url
     assert_match /fog-smoke-test/, public_url
+  end
+
+  def test_public
+    skip
+  end
+
+  def test_files
+    skip
+  end
+
+  def test_acl
+    skip
   end
 end

--- a/test/integration/storage/test_directories.rb
+++ b/test/integration/storage/test_directories.rb
@@ -2,11 +2,13 @@ require "helpers/integration_test_helper"
 
 class TestBuckets < FogIntegrationTest
   begin
+    client_email = Fog.credentials[:google_client_email]
     @@connection = Fog::Google::StorageJSON.new
-    @@connection.put_bucket("fog-smoke-test", options = { "predefinedAcl" => "publicReadWrite" })
+    @@connection.put_bucket("fog-smoke-test", options = { "acl" => [{ entity: "user-" + client_email, role: "OWNER" }] })
+    @@connection.put_bucket_acl("fog-smoke-test", { entity: "allUsers", role: "READER" })
     @@directory = @@connection.directories.get("fog-smoke-test")
   rescue Exception => e
-    # puts e
+    puts e
   end
 
   Minitest.after_run do
@@ -14,7 +16,7 @@ class TestBuckets < FogIntegrationTest
       @connection = Fog::Google::StorageJSON.new
       @connection.delete_bucket("fog-smoke-test")
     rescue Exception => e
-      # puts e
+      puts e
     end
   end
 

--- a/test/integration/storage/test_directories.rb
+++ b/test/integration/storage/test_directories.rb
@@ -1,6 +1,6 @@
 require "helpers/integration_test_helper"
 
-class TestBuckets < FogIntegrationTest
+class TestDirectories < FogIntegrationTest
   begin
     client_email = Fog.credentials[:google_client_email]
     @@connection = Fog::Google::StorageJSON.new

--- a/test/integration/storage/test_directories.rb
+++ b/test/integration/storage/test_directories.rb
@@ -1,0 +1,42 @@
+require "helpers/integration_test_helper"
+
+class TestBuckets < FogIntegrationTest
+  begin
+    @@connection = Fog::Google::StorageJSON.new
+    @@connection.put_bucket("fog-smoke-test", options = { "predefinedAcl" => "publicReadWrite" })
+    @@directory = @@connection.directories.get("fog-smoke-test")
+  rescue Exception => e
+    # puts e
+  end
+
+  Minitest.after_run do
+    begin
+      @connection = Fog::Google::StorageJSON.new
+      @connection.delete_bucket("fog-smoke-test")
+    rescue Exception => e
+      # puts e
+    end
+  end
+
+  def setup
+    @connection = @@connection
+    @directory = @@directory
+  end
+
+  def test_get_directory
+    directory_get = @connection.directories.get("fog-smoke-test")
+    assert_instance_of Fog::Google::StorageJSON::Directory, directory_get
+  end
+
+  def test_create_destroy_directory
+    directory_create = @connection.directories.create(key: "fog-smoke-test-create-destroy")
+    assert_instance_of Fog::Google::StorageJSON::Directory, directory_create
+    assert directory_create.destroy
+  end
+
+  def test_public_url_directory
+    public_url = @directory.public_url
+    assert_match /storage\.googleapis\.com/, public_url
+    assert_match /fog-smoke-test/, public_url
+  end
+end

--- a/test/integration/storage/test_files.rb
+++ b/test/integration/storage/test_files.rb
@@ -1,0 +1,95 @@
+require "helpers/integration_test_helper"
+
+class TestFiles < FogIntegrationTest
+  begin
+    client_email = Fog.credentials[:google_client_email]
+    @@connection = Fog::Google::StorageJSON.new
+    @@connection.put_bucket("fog-smoke-test", options = { "acl" => [{ entity: "user-" + client_email, role: "OWNER" }] })
+    @@connection.put_bucket_acl("fog-smoke-test", { entity: "allUsers", role: "READER" })
+    @@directory = @@connection.directories.get("fog-smoke-test")
+  rescue Exception => e
+    puts e
+  end
+
+  Minitest.after_run do
+    begin
+      @connection = Fog::Google::StorageJSON.new
+      @connection.delete_bucket("fog-smoke-test")
+    rescue Exception => e
+      puts e
+    end
+  end
+
+  def setup
+    @connection = @@connection
+    @directory = @@directory
+  end
+
+  def test_all_files
+    skip
+  end
+
+  def test_each_files
+    skip
+  end
+
+  def test_get
+    skip
+  end
+
+  def test_get_https_url
+    skip
+  end
+
+  def test_head
+    skip
+  end
+
+  def test_new
+    skip
+  end
+
+  def test_acl
+    skip
+  end
+
+  def test_body
+    skip
+  end
+
+  def test_set_body
+    skip
+  end
+
+  def test_copy
+    skip
+  end
+
+  def test_create_destroy
+    skip
+  end
+
+  def test_metadata
+    skip
+  end
+
+  def test_set_metdata
+    skip
+  end
+
+  def test_set_owner
+    skip
+  end
+
+  def test_set_public
+    skip
+  end
+
+  def test_public_url
+    skip
+  end
+
+  def test_url
+    skip
+  end
+end

--- a/test/integration/storage/test_objects.rb
+++ b/test/integration/storage/test_objects.rb
@@ -2,9 +2,6 @@ require "helpers/integration_test_helper"
 
 class TestObjects < FogIntegrationTest
   def setup
-    # Uncomment this if you want to make real requests to GCE (you _will_ be billed!)
-    # WebMock.disable!
-
     @connection = Fog::Google::StorageJSON.new
 
     begin

--- a/test/integration/storage/test_objects.rb
+++ b/test/integration/storage/test_objects.rb
@@ -1,0 +1,85 @@
+require "helpers/integration_test_helper"
+
+class TestObjects < FogIntegrationTest
+  def setup
+    # Uncomment this if you want to make real requests to GCE (you _will_ be billed!)
+    # WebMock.disable!
+
+    @connection = Fog::Google::StorageJSON.new
+
+    begin
+      @connection.put_bucket("fog-smoke-test", options={ 'x-goog-acl' => 'publicReadWrite' })
+    rescue
+    end
+  end
+
+  def teardown
+    begin
+      @connection.delete_object("fog-smoke-test", "my file")
+    rescue
+    end
+    begin
+      @connection.delete_object("fog-smoke-test", "my file copy")
+    rescue
+    end
+    begin
+      @connection.delete_bucket("fog-smoke-test")
+    rescue
+    end
+  end
+
+  def test_put_object
+    response = @connection.put_object("fog-smoke-test", "my file", "THISISATESTFILE")
+    assert_equal response.status, 200
+  end
+
+  def test_put_object_acl
+    skip
+  end
+
+  def test_put_object_url
+    skip
+  end
+
+  def test_copy_object
+    response = @connection.put_object("fog-smoke-test", "my file", "THISISATESTFILE")
+    assert_equal response.status, 200
+    response = @connection.copy_object("fog-smoke-test", "my file", "fog-smoke-test", "my file copy")
+    assert_equal response.status, 200
+  end
+
+  def test_delete_object
+    response = @connection.put_object("fog-smoke-test", "my file", "THISISATESTFILE")
+    assert_equal response.status, 200
+    response = @connection.delete_object("fog-smoke-test", "my file")
+    assert_equal response.status, 204
+  end
+
+  def test_get_object
+    skip
+  end
+
+  def test_get_object_acl
+    skip
+  end
+
+  def test_get_object_http_url
+    skip
+  end
+
+  def test_get_object_https_url
+    skip
+  end
+
+  def test_get_object_url
+    skip
+  end
+
+  def test_get_object_torrent
+    skip
+  end
+
+  def test_head_object
+    skip
+  end
+end

--- a/test/integration/storage/test_objects.rb
+++ b/test/integration/storage/test_objects.rb
@@ -1,12 +1,10 @@
 require "helpers/integration_test_helper"
 
 def before_run
-  begin
-    @connection = Fog::Google::StorageJSON.new
-    @connection.put_bucket("fog-smoke-test", options={ 'x-goog-acl' => 'publicReadWrite' })
-  rescue Exception => e
-    # puts e
-  end
+  @connection = Fog::Google::StorageJSON.new
+  @connection.put_bucket("fog-smoke-test", options = { "x-goog-acl" => "publicReadWrite" })
+rescue Exception => e
+  # puts e
 end
 before_run
 
@@ -43,8 +41,8 @@ class TestObjects < FogIntegrationTest
   def test_put_object_acl
     response = @connection.put_object("fog-smoke-test", "my file", "THISISATESTFILE")
     assert_equal response.status, 200
-    acl = { entity: 'domain-example.com',
-            role: 'READER' }
+    acl = { entity: "domain-example.com",
+            role: "READER" }
     response = @connection.put_object_acl("fog-smoke-test", "my file", acl)
     assert_equal response.status, 200
   end

--- a/test/integration/storage/test_objects.rb
+++ b/test/integration/storage/test_objects.rb
@@ -88,11 +88,18 @@ class TestObjects < FogIntegrationTest
   end
 
   def test_get_object_https_url
-    skip
+    response = @connection.put_object("fog-smoke-test", "my file", "THISISATESTFILE")
+    assert_equal response.status, 200
+    https_url = @connection.get_object_https_url("fog-smoke-test", "my file")
+    assert_equal https_url, "https://www.googleapis.com/storage/v1/b/fog-smoke-test/o/my%20file"
   end
 
   def test_get_object_url
     skip
+    response = @connection.put_object("fog-smoke-test", "my file", "THISISATESTFILE")
+    assert_equal response.status, 200
+    https_url = @connection.get_object_url("fog-smoke-test", "my file")
+    assert_equal https_url, "https://www.googleapis.com/storage/v1/b/fog-smoke-test/o/my%20file"
   end
 
   def test_get_object_torrent

--- a/test/integration/storage/test_objects.rb
+++ b/test/integration/storage/test_objects.rb
@@ -52,6 +52,10 @@ class TestObjects < FogIntegrationTest
 
   def test_put_object_url
     skip
+    # Doesn't actually work
+    response = @connection.put_object_url("fog-smoke-test", "my file url")
+    puts response.inspect
+    assert_equal response.status, 200
   end
 
   def test_copy_object
@@ -69,7 +73,10 @@ class TestObjects < FogIntegrationTest
   end
 
   def test_get_object
-    skip
+    response = @connection.put_object("fog-smoke-test", "my file", "THISISATESTFILE")
+    assert_equal response.status, 200
+    response = @connection.get_object("fog-smoke-test", "my file")
+    assert_equal response.status, 200
   end
 
   def test_get_object_acl

--- a/test/integration/storage/test_objects.rb
+++ b/test/integration/storage/test_objects.rb
@@ -5,19 +5,18 @@ def before_run
     @connection = Fog::Google::StorageJSON.new
     @connection.put_bucket("fog-smoke-test", options={ 'x-goog-acl' => 'publicReadWrite' })
   rescue Exception => e
-    puts e
+    # puts e
   end
 end
 before_run
 
 class TestObjects < FogIntegrationTest
   Minitest.after_run do
-    puts "after run!"
     begin
       @connection = Fog::Google::StorageJSON.new
       @connection.delete_bucket("fog-smoke-test")
     rescue Exception => e
-      puts e
+      # puts e
     end
   end
 
@@ -80,7 +79,11 @@ class TestObjects < FogIntegrationTest
   end
 
   def test_get_object_acl
-    skip
+    response = @connection.put_object("fog-smoke-test", "my file", "THISISATESTFILE")
+    assert_equal response.status, 200
+    response = @connection.get_object_acl("fog-smoke-test", "my file")
+    assert_equal response.status, 200
+    assert_equal response.body["kind"], "storage#objectAccessControls"
   end
 
   def test_get_object_http_url

--- a/test/integration/storage/test_objects.rb
+++ b/test/integration/storage/test_objects.rb
@@ -89,10 +89,12 @@ class TestObjects < FogIntegrationTest
   end
 
   def test_get_object_https_url
-    response = @connection.put_object("fog-smoke-test", "my file", "THISISATESTFILE")
+    response = @connection.put_object("fog-smoke-test", "my file", "THISISATESTFILE", options={ predefinedAcl: 'publicRead' })
     assert_equal response.status, 200
     https_url = @connection.get_object_https_url("fog-smoke-test", "my file")
-    assert_equal https_url, "https://www.googleapis.com/storage/v1/b/fog-smoke-test/o/my%20file"
+    assert_match /https/, https_url
+    assert_match /fog-smoke-test/, https_url
+    assert_match /my%20file/, https_url
   end
 
   def test_get_object_url

--- a/test/integration/storage/test_objects.rb
+++ b/test/integration/storage/test_objects.rb
@@ -2,7 +2,7 @@ require "helpers/integration_test_helper"
 
 def before_run
   @connection = Fog::Google::StorageJSON.new
-  @connection.put_bucket("fog-smoke-test", options = { "x-goog-acl" => "publicReadWrite" })
+  @connection.put_bucket("fog-smoke-test", options = { "predefinedAcl" => "publicReadWrite" })
 rescue Exception => e
   # puts e
 end


### PR DESCRIPTION
Here's another partial progress PR. This includes tests for objects, buckets and directories, which are mostly working. It also removes the Faraday/httpclient changes I made earlier in favor of multipart uploads and the request function used by other parts of the gem.

Some things I'm coming across that I have questions about:

The JSON API uses different parameter names and accepted values than the XML API. For example: `x-goog-acl` is replaced by `predefinedAcl` in most options locations. Can I update that here assuming that the requests will be interacted with primarily through the `directories` and `files` models, or do we need to accept these parameter names for backwards-compatibility?

One major problem with the service accounts is that they are not immediately given ownership of buckets/objects they create. This means any put_bucket or put_object request has to have an `acl` defined that gives the service account permission to operate on it, or it won't be able to modify it later. Is this something we want to do by default? Is there any reason not to do that, and if so, how would we make this work?

It's not immediately apparent what URL should be returned by the `get_object_https_url` request. I've provided the `mediaLink` which allows the object to be downloaded, but that might not be correct. There doesn't seem to be a way to generate a HTTP URL or a torrent (not that's obvious) in the JSON API. 

More coming here soon, I'll be adding files tests and filling out the directories tests next. Would love to discuss this progress and what we need to do to get this functional, hit me up on Gchat sometime today.
