### PR TITLE
New storage api

### DIFF
--- a/lib/fog/google/models/storage_json/file.rb
+++ b/lib/fog/google/models/storage_json/file.rb
@@ -7,6 +7,7 @@ module Fog
         identity :key, :aliases => "Key"
 
         # TODO: Verify
+        attribute :acl
         attribute :cache_control,       :aliases => "cacheControl"
         attribute :content_disposition, :aliases => "contentDisposition"
         attribute :content_encoding,    :aliases => "contentEncoding"
@@ -23,16 +24,6 @@ module Fog
         attribute :media_link,          :aliases => "mediaLink"
         attribute :owner
         attribute :storage_class,       :aliases => "storageClass"
-
-        # TODO: Verify
-        # This is completely wrong, we need a list of ACLs and not a single word.
-        def acl=(new_acl)
-          valid_acls = ["private", "projectPrivate", "bucketOwnerFullControl", "bucketOwnerRead", "authenticatedRead", "publicRead"]
-          unless valid_acls.include?(new_acl)
-            raise ArgumentError.new("acl must be one of [#{valid_acls.join(', ')}]")
-          end
-          @acl = new_acl
-        end
 
         # TODO: Verify
         def body

--- a/lib/fog/google/models/storage_json/file.rb
+++ b/lib/fog/google/models/storage_json/file.rb
@@ -57,6 +57,12 @@ module Fog
         end
 
         # TODO: Verify
+        remove_method :metadata=
+        def metadata=(new_metadata)
+          metadata.merge!(new_metadata)
+        end
+
+        # TODO: Verify
         remove_method :owner=
         def owner=(new_owner)
           if new_owner
@@ -106,7 +112,7 @@ module Fog
           options["contentEncoding"] = content_encoding if content_encoding
           options["md5Hash"] = content_md5 if content_md5
           options["crc32c"] = crc32c if crc32c
-          options.merge!(metadata)
+          options["metadata"] = metadata
 
           data = service.put_object(directory.key, key, body, options)
           merge_attributes(data.headers.reject { |key, _value| ["Content-Length", "Content-Type"].include?(key) })

--- a/lib/fog/google/models/storage_json/file.rb
+++ b/lib/fog/google/models/storage_json/file.rb
@@ -8,6 +8,7 @@ module Fog
 
         # TODO: Verify
         attribute :acl
+        attribute :predefined_acl
         attribute :cache_control,       :aliases => "cacheControl"
         attribute :content_disposition, :aliases => "contentDisposition"
         attribute :content_encoding,    :aliases => "contentEncoding"

--- a/lib/fog/google/models/storage_json/file.rb
+++ b/lib/fog/google/models/storage_json/file.rb
@@ -14,6 +14,7 @@ module Fog
         attribute :content_length,      :aliases => "size", :type => :integer
         attribute :content_md5,         :aliases => "md5Hash"
         attribute :content_type,        :aliases => "contentType"
+        attribute :crc32c
         attribute :etag,                :aliases => "etag"
         attribute :time_created,        :aliases => "timeCreated"
         attribute :last_modified,       :aliases => "updated"
@@ -54,18 +55,6 @@ module Fog
           end
           true
         end
-
-        # # TODO: Verify
-        # remove_method :metadata
-        # def metadata
-        #   attributes.reject { |key, _value| !(key.to_s =~ /^x-goog-meta-/) }
-        # end
-
-        # # TODO: Verify
-        # remove_method :metadata=
-        # def metadata=(new_metadata)
-        #   merge_attributes(new_metadata)
-        # end
 
         # TODO: Verify
         remove_method :owner=
@@ -110,12 +99,13 @@ module Fog
           if options != {}
             Fog::Logger.deprecation("options param is deprecated, use acl= instead [light_black](#{caller.first})[/]")
           end
-          # options["predefinedAcl"] ||= @acl if @acl
+          options["contentType"] = content_type if content_type
+          options["acl"] ||= @acl if @acl
           options["cacheControl"] = cache_control if cache_control
           options["contentDisposition"] = content_disposition if content_disposition
           options["contentEncoding"] = content_encoding if content_encoding
           options["md5Hash"] = content_md5 if content_md5
-          options["contentType"] = content_type if content_type
+          options["crc32c"] = crc32c if crc32c
           options.merge!(metadata)
 
           data = service.put_object(directory.key, key, body, options)

--- a/lib/fog/google/models/storage_json/files.rb
+++ b/lib/fog/google/models/storage_json/files.rb
@@ -18,6 +18,7 @@ module Fog
 
         model Fog::Google::StorageJSON::File
 
+        # TODO: Verify, probably doesn't work
         def all(options = {})
           requires :directory
           options = {
@@ -38,6 +39,7 @@ module Fog
           end
         end
 
+        # TODO: Verify
         alias_method :each_file_this_page, :each
         def each
           if !block_given?

--- a/lib/fog/google/models/storage_json/files.rb
+++ b/lib/fog/google/models/storage_json/files.rb
@@ -69,14 +69,9 @@ module Fog
           nil
         end
 
-        def get_http_url(key, expires)
+        def get_https_url(key)
           requires :directory
-          service.get_object_http_url(directory.key, key, expires)
-        end
-
-        def get_https_url(key, expires)
-          requires :directory
-          service.get_object_https_url(directory.key, key, expires)
+          service.get_object_https_url(directory.key, key)
         end
 
         def head(key, options = {})

--- a/lib/fog/google/requests/storage_json/get_object.rb
+++ b/lib/fog/google/requests/storage_json/get_object.rb
@@ -31,7 +31,8 @@ module Fog
           api_method = @storage_json.objects.get
           parameters = {
             "bucket" => bucket_name,
-            "object" => object_name
+            "object" => object_name,
+            "projection" => "full"
           }
 
           object = request(api_method, parameters)

--- a/lib/fog/google/requests/storage_json/get_object.rb
+++ b/lib/fog/google/requests/storage_json/get_object.rb
@@ -44,8 +44,8 @@ module Fog
           }
 
           result = @client.execute(client_parms)
+          object.headers = object.body
           object.body = result.body.nil? || result.body.empty? ? nil : result.body
-          
           object
 
           # params = { :headers => {} }

--- a/lib/fog/google/requests/storage_json/get_object.rb
+++ b/lib/fog/google/requests/storage_json/get_object.rb
@@ -28,13 +28,25 @@ module Fog
           raise ArgumentError.new("bucket_name is required") unless bucket_name
           raise ArgumentError.new("object_name is required") unless object_name
 
-          api_method = @storage_json.buckets.get
+          api_method = @storage_json.objects.get
           parameters = {
             "bucket" => bucket_name,
             "object" => object_name
           }
 
-          request(api_method, parameters)
+          object = request(api_method, parameters)
+
+          # Get the body of the object (can't use request for this)
+          parameters["alt"] = "media"
+          client_parms = {
+            :api_method => api_method,
+            :parameters => parameters
+          }
+
+          result = @client.execute(client_parms)
+          object.body = result.body.nil? || result.body.empty? ? nil : result.body
+          
+          object
 
           # params = { :headers => {} }
           # if version_id = options.delete("versionId")

--- a/lib/fog/google/requests/storage_json/head_object.rb
+++ b/lib/fog/google/requests/storage_json/head_object.rb
@@ -24,8 +24,21 @@ module Fog
         #     * 'ETag'<~String> - Etag of object
         #     * 'Last-Modified'<~String> - Last modified timestamp for object
         def head_object(bucket_name, object_name, options = {})
-          # raise ArgumentError.new("bucket_name is required") unless bucket_name
-          # raise ArgumentError.new("object_name is required") unless object_name
+          raise ArgumentError.new("bucket_name is required") unless bucket_name
+          raise ArgumentError.new("object_name is required") unless object_name
+
+          api_method = @storage_json.objects.get
+          parameters = {
+            "bucket" => bucket_name,
+            "object" => object_name,
+            "projection" => "full"
+          }
+
+          object = request(api_method, parameters)
+          object.headers = object.body
+          object.body = nil
+          object
+
           # if version_id = options.delete("versionId")
           #   query = { "versionId" => version_id }
           # end
@@ -44,9 +57,9 @@ module Fog
 
       class Mock
         def head_object(bucket_name, object_name, options = {})
-          # response = get_object(bucket_name, object_name, options)
-          # response.body = nil
-          # response
+          response = get_object(bucket_name, object_name, options)
+          response.body = nil
+          response
         end
       end
     end

--- a/lib/fog/google/requests/storage_json/put_bucket.rb
+++ b/lib/fog/google/requests/storage_json/put_bucket.rb
@@ -22,8 +22,8 @@ module Fog
             "projection" => "full"
           }
           body_object = {
-            name: bucket_name,
-            location: location
+            "name" => bucket_name,
+            "location" => location
           }
           parameters.merge! options
 

--- a/lib/fog/google/storage_json.rb
+++ b/lib/fog/google/storage_json.rb
@@ -36,7 +36,7 @@ module Fog
       request :get_object_https_url
       request :get_object_url
       # request :get_service
-      # request :head_object
+      request :head_object
       request :put_bucket
       request :put_bucket_acl
       request :put_object

--- a/test/integration/storage/test_files.rb
+++ b/test/integration/storage/test_files.rb
@@ -118,11 +118,16 @@ class TestFiles < FogIntegrationTest
   end
 
   def test_public_url
-    public_url = @file.public_url
-    assert_match /https/, public_url
-    assert_match /storage\.googleapis\.com/, public_url
-    assert_match /fog-smoke-test/, public_url
-    assert_match /fog-testfile/, public_url
+    assert_nil @file.public_url
+
+    # Setting an ACL still fails, but here's some tests that should work when it does.
+    # @file.acl.push({ "entity" => "allUsers", "role" => "READER" })
+    # public_url = @file.public_url
+
+    # assert_match /https/, public_url
+    # assert_match /storage\.googleapis\.com/, public_url
+    # assert_match /fog-smoke-test/, public_url
+    # assert_match /fog-testfile/, public_url
   end
 
   def test_url

--- a/test/integration/storage/test_files.rb
+++ b/test/integration/storage/test_files.rb
@@ -51,7 +51,10 @@ class TestFiles < FogIntegrationTest
   end
 
   def test_get_https_url
-    skip
+    https_url = @directory.files.get_https_url("fog-testfile")
+    assert_match /https/, https_url
+    assert_match /fog-smoke-test/, https_url
+    assert_match /fog-testfile/, https_url
   end
 
   def test_head
@@ -98,7 +101,7 @@ class TestFiles < FogIntegrationTest
     skip
   end
 
-  def test_set_metdata
+  def test_set_metadata
     skip
   end
 

--- a/test/integration/storage/test_files.rb
+++ b/test/integration/storage/test_files.rb
@@ -58,11 +58,15 @@ class TestFiles < FogIntegrationTest
   end
 
   def test_head
-    skip
+    assert_instance_of Fog::Google::StorageJSON::File, @directory.files.head("fog-testfile")
   end
 
   def test_new
-    skip
+    new_file = @directory.files.new({ 
+      :key => "fog-testfile-new",
+      :body => "TESTFILENEW"
+    })
+    assert_instance_of Fog::Google::StorageJSON::File, new_file
   end
 
   def test_acl
@@ -81,8 +85,8 @@ class TestFiles < FogIntegrationTest
     file_get = @directory.files.get("fog-testfile")
     assert_instance_of Fog::Google::StorageJSON::File, file_get
     assert_equal new_body, file_get.body
-    file_get.body = "THISISATESTFILE"
-    file_get.save
+    @file.body = "THISISATESTFILE"
+    @file.save
   end
 
   def test_copy
@@ -114,7 +118,11 @@ class TestFiles < FogIntegrationTest
   end
 
   def test_public_url
-    skip
+    public_url = @file.public_url
+    assert_match /https/, public_url
+    assert_match /storage\.googleapis\.com/, public_url
+    assert_match /fog-smoke-test/, public_url
+    assert_match /fog-testfile/, public_url
   end
 
   def test_url


### PR DESCRIPTION
This PR concerns changes to the File model. The major update is that attributes are set when the object is created and methods are functional. Although this is meant to be largely unchanged to maintain support in the parent fog gem, I think the JSON API somewhat requires that we change a few things.
1. ACLs come from the JSON API as an array of entity/role relationships. There are predefined ACL strings [allowed in the creation and updating of objects](https://cloud.google.com/storage/docs/json_api/v1/objects/insert) but it seems as though using a predefined ACL prevents you from creating a bucket with allowed permissions for a service account to use them. I've converted the `acl` property on the 
2. Metadata is no longer just the list of attributes with a given prefix. The JSON API returns a hash for metadata, and this function should add new data to that hash or return the hash as normal.

Another general note: I'm not sure about pagination handling for the directories.all and files.all methods. I might put in a stub if I have time before tomorrow.

At this point I think we should touch base and discuss how to get this completed and thoroughly tested. I'm starting to hit a wall where not sure what the right path forward is for the ACL creation and things like setting metadata and changing the keys on the owners. Let's discuss via IM tomorrow if possible.
