### PR TITLE
Return Storage::Google object for API based on credentials

### DIFF
--- a/lib/fog/bin/google.rb
+++ b/lib/fog/bin/google.rb
@@ -74,8 +74,13 @@ module Google # deviates from other bin stuff to accomodate gem
       if availability
         for service in services
           for collection in class_for(service).collections
-            next if self.respond_to?(collection)
-class_eval <<-EOS, __FILE__, __LINE__
+            unless self.respond_to?(collection)
+              class_eval <<-EOS, __FILE__, __LINE__
+                def self.#{collection}
+                  self[:#{service}].#{collection}
+                end
+              EOS
+            end
           end
         end
       end

--- a/lib/fog/bin/google.rb
+++ b/lib/fog/bin/google.rb
@@ -74,13 +74,8 @@ module Google # deviates from other bin stuff to accomodate gem
       if availability
         for service in services
           for collection in class_for(service).collections
-            unless self.respond_to?(collection)
-              class_eval <<-EOS, __FILE__, __LINE__
-                def self.#{collection}
-                  self[:#{service}].#{collection}
-                end
-              EOS
-            end
+            next if self.respond_to?(collection)
+class_eval <<-EOS, __FILE__, __LINE__
           end
         end
       end

--- a/lib/fog/google/models/storage/directories.rb
+++ b/lib/fog/google/models/storage/directories.rb
@@ -3,9 +3,9 @@ require "fog/google/models/storage/directory"
 
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class Directories < Fog::Collection
-        model Fog::Storage::Google::Directory
+        model Fog::Storage::GoogleXML::Directory
 
         def all
           data = service.get_service.body["Buckets"]

--- a/lib/fog/google/models/storage/directory.rb
+++ b/lib/fog/google/models/storage/directory.rb
@@ -27,7 +27,7 @@ module Fog
 
         def files
           @files ||= begin
-            Fog::Storage::Google::Files.new(
+            Fog::Storage::GoogleXML::Files.new(
               :directory => self,
               :service => service
             )

--- a/lib/fog/google/models/storage/directory.rb
+++ b/lib/fog/google/models/storage/directory.rb
@@ -3,7 +3,7 @@ require "fog/google/models/storage/files"
 
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class Directory < Fog::Model
         identity :key, :aliases => %w(Name name)
 

--- a/lib/fog/google/models/storage/file.rb
+++ b/lib/fog/google/models/storage/file.rb
@@ -2,7 +2,7 @@ require "fog/core/model"
 
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class File < Fog::Model
         identity :key, :aliases => "Key"
 

--- a/lib/fog/google/models/storage/files.rb
+++ b/lib/fog/google/models/storage/files.rb
@@ -3,7 +3,7 @@ require "fog/google/models/storage/file"
 
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class Files < Fog::Collection
         extend Fog::Deprecation
         deprecate :get_url, :get_https_url
@@ -16,7 +16,7 @@ module Fog
         attribute :max_keys,        :aliases => ["MaxKeys", "max-keys"]
         attribute :prefix,          :aliases => "Prefix"
 
-        model Fog::Storage::Google::File
+        model Fog::Storage::GoogleXML::File
 
         def all(options = {})
           requires :directory

--- a/lib/fog/google/models/storage_json/directories.rb
+++ b/lib/fog/google/models/storage_json/directories.rb
@@ -3,9 +3,9 @@ require "fog/google/models/storage_json/directory"
 
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Directories < Fog::Collection
-        model Fog::Storage::Google::Directory
+        model Fog::Storage::GoogleJSON::Directory
 
         def all
           data = service.get_service.body["items"]

--- a/lib/fog/google/models/storage_json/directory.rb
+++ b/lib/fog/google/models/storage_json/directory.rb
@@ -25,7 +25,7 @@ module Fog
 
         def files
           @files ||= begin
-            Fog::Storage::Google::Files.new(
+            Fog::Storage::GoogleJSON::Files.new(
               :directory => self,
               :service => service
             )

--- a/lib/fog/google/models/storage_json/directory.rb
+++ b/lib/fog/google/models/storage_json/directory.rb
@@ -3,7 +3,7 @@ require "fog/google/models/storage_json/files"
 
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Directory < Fog::Model
         identity :key, :aliases => %w(Name name)
 

--- a/lib/fog/google/models/storage_json/file.rb
+++ b/lib/fog/google/models/storage_json/file.rb
@@ -2,7 +2,7 @@ require "fog/core/model"
 
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class File < Fog::Model
         identity :key, :aliases => "Key"
 

--- a/lib/fog/google/models/storage_json/files.rb
+++ b/lib/fog/google/models/storage_json/files.rb
@@ -12,7 +12,7 @@ module Fog
         attribute :delimiter,       :aliases => "Delimiter"
         attribute :directory
         # attribute :is_truncated,    :aliases => "IsTruncated"
-        attribute :page_token,      :aliases => ["pageToken", "page_token"]
+        attribute :page_token,      :aliases => %w(pageToken page_token)
         attribute :max_results,     :aliases => ["MaxKeys", "max-keys"]
         attribute :prefix,          :aliases => "Prefix"
 

--- a/lib/fog/google/models/storage_json/files.rb
+++ b/lib/fog/google/models/storage_json/files.rb
@@ -3,7 +3,7 @@ require "fog/google/models/storage_json/file"
 
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Files < Fog::Collection
         extend Fog::Deprecation
         deprecate :get_url, :get_https_url
@@ -16,7 +16,7 @@ module Fog
         attribute :max_results,     :aliases => ["MaxKeys", "max-keys"]
         attribute :prefix,          :aliases => "Prefix"
 
-        model Fog::Storage::Google::File
+        model Fog::Storage::GoogleJSON::File
 
         # TODO: Verify, probably doesn't work
         def all(options = {})

--- a/lib/fog/google/requests/storage/copy_object.rb
+++ b/lib/fog/google/requests/storage/copy_object.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class Real
         require "fog/google/parsers/storage/copy_object"
 

--- a/lib/fog/google/requests/storage/delete_bucket.rb
+++ b/lib/fog/google/requests/storage/delete_bucket.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class Real
         # Delete an Google Storage bucket
         #

--- a/lib/fog/google/requests/storage/delete_object.rb
+++ b/lib/fog/google/requests/storage/delete_object.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class Real
         # Delete an object from Google Storage
         #

--- a/lib/fog/google/requests/storage/get_bucket.rb
+++ b/lib/fog/google/requests/storage/get_bucket.rb
@@ -1,7 +1,7 @@
 require "pp"
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class Real
         require "fog/google/parsers/storage/get_bucket"
 

--- a/lib/fog/google/requests/storage/get_bucket_acl.rb
+++ b/lib/fog/google/requests/storage/get_bucket_acl.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class Real
         require "fog/google/parsers/storage/access_control_list"
 

--- a/lib/fog/google/requests/storage/get_object.rb
+++ b/lib/fog/google/requests/storage/get_object.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class Real
         # Get an object from Google Storage
         #

--- a/lib/fog/google/requests/storage/get_object_acl.rb
+++ b/lib/fog/google/requests/storage/get_object_acl.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class Real
         require "fog/google/parsers/storage/access_control_list"
 

--- a/lib/fog/google/requests/storage/get_object_http_url.rb
+++ b/lib/fog/google/requests/storage/get_object_http_url.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       module GetObjectHttpUrl
         def get_object_http_url(bucket_name, object_name, expires)
           raise ArgumentError.new("bucket_name is required") unless bucket_name

--- a/lib/fog/google/requests/storage/get_object_https_url.rb
+++ b/lib/fog/google/requests/storage/get_object_https_url.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       module GetObjectHttpsUrl
         def get_object_https_url(bucket_name, object_name, expires)
           raise ArgumentError.new("bucket_name is required") unless bucket_name

--- a/lib/fog/google/requests/storage/get_object_torrent.rb
+++ b/lib/fog/google/requests/storage/get_object_torrent.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class Real
         # Get torrent for an Google Storage object
         #

--- a/lib/fog/google/requests/storage/get_object_url.rb
+++ b/lib/fog/google/requests/storage/get_object_url.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class Real
         # Get an expiring object url from Google Storage
         #

--- a/lib/fog/google/requests/storage/get_service.rb
+++ b/lib/fog/google/requests/storage/get_service.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class Real
         require "fog/google/parsers/storage/get_service"
 

--- a/lib/fog/google/requests/storage/head_object.rb
+++ b/lib/fog/google/requests/storage/head_object.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class Real
         # Get headers for an object from Google Storage
         #

--- a/lib/fog/google/requests/storage/put_bucket.rb
+++ b/lib/fog/google/requests/storage/put_bucket.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class Real
         # Create an Google Storage bucket
         #

--- a/lib/fog/google/requests/storage/put_bucket_acl.rb
+++ b/lib/fog/google/requests/storage/put_bucket_acl.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class Mock
         def put_bucket_acl(_bucket_name, _acl)
           Fog::Mock.not_implemented

--- a/lib/fog/google/requests/storage/put_object.rb
+++ b/lib/fog/google/requests/storage/put_object.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class Real
         # Create an object in an Google Storage bucket
         #

--- a/lib/fog/google/requests/storage/put_object_acl.rb
+++ b/lib/fog/google/requests/storage/put_object_acl.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class Real
         # TODO: move this methods to helper to use them with put_bucket_acl request
         def tag(name, value)

--- a/lib/fog/google/requests/storage/put_object_url.rb
+++ b/lib/fog/google/requests/storage/put_object_url.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleXML
       class Real
         # Get an expiring object url from Google Storage for putting an object
         #

--- a/lib/fog/google/requests/storage_json/copy_object.rb
+++ b/lib/fog/google/requests/storage_json/copy_object.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Real
         require "fog/google/parsers/storage/copy_object"
 

--- a/lib/fog/google/requests/storage_json/delete_bucket.rb
+++ b/lib/fog/google/requests/storage_json/delete_bucket.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Real
         # Delete an Google Storage bucket
         #

--- a/lib/fog/google/requests/storage_json/delete_object.rb
+++ b/lib/fog/google/requests/storage_json/delete_object.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Real
         # Delete an object from Google Storage
         #

--- a/lib/fog/google/requests/storage_json/get_bucket.rb
+++ b/lib/fog/google/requests/storage_json/get_bucket.rb
@@ -1,7 +1,7 @@
 require "pp"
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Real
         require "fog/google/parsers/storage/get_bucket"
 

--- a/lib/fog/google/requests/storage_json/get_bucket_acl.rb
+++ b/lib/fog/google/requests/storage_json/get_bucket_acl.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Real
         require "fog/google/parsers/storage/access_control_list"
 

--- a/lib/fog/google/requests/storage_json/get_object.rb
+++ b/lib/fog/google/requests/storage_json/get_object.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Real
         # Get an object from Google Storage
         #

--- a/lib/fog/google/requests/storage_json/get_object_acl.rb
+++ b/lib/fog/google/requests/storage_json/get_object_acl.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Real
         require "fog/google/parsers/storage/access_control_list"
 

--- a/lib/fog/google/requests/storage_json/get_object_http_url.rb
+++ b/lib/fog/google/requests/storage_json/get_object_http_url.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       module GetObjectHttpUrl
         def get_object_http_url(bucket_name, object_name, expires)
           # raise ArgumentError.new("bucket_name is required") unless bucket_name

--- a/lib/fog/google/requests/storage_json/get_object_https_url.rb
+++ b/lib/fog/google/requests/storage_json/get_object_https_url.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       module GetObjectHttpsUrl
         # Formerly included "expires", but no doesn't seem to exist anymore?
         def get_object_https_url(bucket_name, object_name)

--- a/lib/fog/google/requests/storage_json/get_object_torrent.rb
+++ b/lib/fog/google/requests/storage_json/get_object_torrent.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Real
         # Get torrent for an Google Storage object
         #

--- a/lib/fog/google/requests/storage_json/get_object_url.rb
+++ b/lib/fog/google/requests/storage_json/get_object_url.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Real
         # Get an expiring object url from Google Storage
         #

--- a/lib/fog/google/requests/storage_json/get_service.rb
+++ b/lib/fog/google/requests/storage_json/get_service.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Real
         require "fog/google/parsers/storage/get_service"
 

--- a/lib/fog/google/requests/storage_json/head_object.rb
+++ b/lib/fog/google/requests/storage_json/head_object.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Real
         # Get headers for an object from Google Storage
         #

--- a/lib/fog/google/requests/storage_json/list_objects.rb
+++ b/lib/fog/google/requests/storage_json/list_objects.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Real
         # Get an object from Google Storage
         #

--- a/lib/fog/google/requests/storage_json/put_bucket.rb
+++ b/lib/fog/google/requests/storage_json/put_bucket.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Real
         # Create an Google Storage bucket
         #

--- a/lib/fog/google/requests/storage_json/put_bucket_acl.rb
+++ b/lib/fog/google/requests/storage_json/put_bucket_acl.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Mock
         def put_bucket_acl(_bucket_name, _acl)
           Fog::Mock.not_implemented

--- a/lib/fog/google/requests/storage_json/put_object.rb
+++ b/lib/fog/google/requests/storage_json/put_object.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Real
         # Create an object in an Google Storage bucket
         #

--- a/lib/fog/google/requests/storage_json/put_object_acl.rb
+++ b/lib/fog/google/requests/storage_json/put_object_acl.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Real
         # TODO: move this methods to helper to use them with put_bucket_acl request
         def tag(name, value)

--- a/lib/fog/google/requests/storage_json/put_object_url.rb
+++ b/lib/fog/google/requests/storage_json/put_object_url.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google
+    class GoogleJSON
       class Real
         # Get an expiring object url from Google Storage for putting an object
         #

--- a/lib/fog/google/storage.rb
+++ b/lib/fog/google/storage.rb
@@ -1,5 +1,19 @@
-if Fog.credentials.keys.include? :google_storage_access_key_id
-  require "fog/google/storage_xml"
-else
-  require "fog/google/storage_json"
+require "fog/google/storage_xml"
+require "fog/google/storage_json"
+
+module Fog
+  module Storage
+    class Google < Fog::Service     
+      def self.new(options)
+        if options.keys.include? :google_storage_access_key_id
+          puts "Loading Fog::Storage::GoogleXML"
+          Fog::Storage::GoogleXML.new(options)
+        else
+          puts "Loading Fog::Storage::GoogleJSON"
+          Fog::Storage::GoogleJSON.new(options)
+        end
+      end
+    end
+  end
 end
+

--- a/lib/fog/google/storage.rb
+++ b/lib/fog/google/storage.rb
@@ -5,10 +5,10 @@ module Fog
   module Storage
     class Google < Fog::Service     
       def self.new(options)
-        if options.keys.include? :google_storage_access_key_id
-          Fog::Storage::GoogleXML.new(options)
-        else
+        if options.keys.join(' ').include? "key"
           Fog::Storage::GoogleJSON.new(options)
+        else
+          Fog::Storage::GoogleXML.new(options)
         end
       end
     end

--- a/lib/fog/google/storage.rb
+++ b/lib/fog/google/storage.rb
@@ -6,10 +6,8 @@ module Fog
     class Google < Fog::Service     
       def self.new(options)
         if options.keys.include? :google_storage_access_key_id
-          puts "Loading Fog::Storage::GoogleXML"
           Fog::Storage::GoogleXML.new(options)
         else
-          puts "Loading Fog::Storage::GoogleJSON"
           Fog::Storage::GoogleJSON.new(options)
         end
       end

--- a/lib/fog/google/storage.rb
+++ b/lib/fog/google/storage.rb
@@ -3,9 +3,9 @@ require "fog/google/storage_json"
 
 module Fog
   module Storage
-    class Google < Fog::Service     
+    class Google < Fog::Service
       def self.new(options)
-        if options.keys.join(' ').include? "key"
+        if options.keys.join(" ").include? "key"
           Fog::Storage::GoogleJSON.new(options)
         else
           Fog::Storage::GoogleXML.new(options)
@@ -14,4 +14,3 @@ module Fog
     end
   end
 end
-

--- a/lib/fog/google/storage_json.rb
+++ b/lib/fog/google/storage_json.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google < Fog::Service
+    class GoogleJSON < Fog::Service
       requires :google_project
       recognizes :google_client_email, :google_key_location, :google_key_string, :google_client,
                  :app_name, :app_version, :google_json_key_location, :google_json_key_string

--- a/lib/fog/google/storage_xml.rb
+++ b/lib/fog/google/storage_xml.rb
@@ -224,12 +224,12 @@ module Fog
 
         def signature(params)
           string_to_sign =
-      <<-DATA
-      #{params[:method]}
-      #{params[:headers]['Content-MD5']}
-      #{params[:headers]['Content-Type']}
-      #{params[:headers]['Date']}
-      DATA
+<<-DATA
+#{params[:method]}
+#{params[:headers]['Content-MD5']}
+#{params[:headers]['Content-Type']}
+#{params[:headers]['Date']}
+DATA
 
           google_headers = {}
           canonical_google_headers = ""

--- a/lib/fog/google/storage_xml.rb
+++ b/lib/fog/google/storage_xml.rb
@@ -1,6 +1,6 @@
 module Fog
   module Storage
-    class Google < Fog::Service
+    class GoogleXML < Fog::Service
       requires :google_storage_access_key_id, :google_storage_secret_access_key
       recognizes :host, :port, :scheme, :persistent, :path_style
 


### PR DESCRIPTION
Rather than require separate files for each API based on the credentials Fog has on load, we should load the correct API for each new instantiation of `Fog::Storage` as each one can have its own credentials.

This PR is not quite ready to merge, but I'm opening it anyway.
