### PR TITLE
Signed URLs with service account keys

### DIFF
--- a/lib/fog/google/requests/storage_json/get_object_http_url.rb
+++ b/lib/fog/google/requests/storage_json/get_object_http_url.rb
@@ -3,14 +3,14 @@ module Fog
     class GoogleJSON
       module GetObjectHttpUrl
         def get_object_http_url(bucket_name, object_name, expires)
-          # raise ArgumentError.new("bucket_name is required") unless bucket_name
-          # raise ArgumentError.new("object_name is required") unless object_name
-          # http_url({
-          #            :headers  => {},
-          #            :host     => @host,
-          #            :method   => "GET",
-          #            :path     => "#{bucket_name}/#{object_name}"
-          #          }, expires)
+          raise ArgumentError.new("bucket_name is required") unless bucket_name
+          raise ArgumentError.new("object_name is required") unless object_name
+          http_url({
+                     :headers  => {},
+                     :host     => @host,
+                     :method   => "GET",
+                     :path     => "#{bucket_name}/#{object_name}"
+                   }, expires)
         end
       end
 

--- a/lib/fog/google/requests/storage_json/get_object_https_url.rb
+++ b/lib/fog/google/requests/storage_json/get_object_https_url.rb
@@ -2,25 +2,21 @@ module Fog
   module Storage
     class GoogleJSON
       module GetObjectHttpsUrl
-        # Formerly included "expires", but no doesn't seem to exist anymore?
-        def get_object_https_url(bucket_name, object_name)
+        #
+        # === See Google Docs information on signed URLs
+        # https://cloud.google.com/storage/docs/access-control#Signed-URLs
+        #
+
+        def get_object_https_url(bucket_name, object_name, expires)
           raise ArgumentError.new("bucket_name is required") unless bucket_name
           raise ArgumentError.new("object_name is required") unless object_name
 
-          api_method = @storage_json.objects.get
-          parameters = {
-            "bucket" => bucket_name,
-            "object" => object_name
-          }
-
-          response = request(api_method, parameters)
-          response.body["mediaLink"]
-          # https_url({
-          #             :headers  => {},
-          #             :host     => @host,
-          #             :method   => "GET",
-          #             :path     => "#{bucket_name}/#{object_name}"
-          #           }, expires)
+          https_url({
+                      :headers  => {},
+                      :host     => @host,
+                      :method   => "GET",
+                      :path     => "#{bucket_name}/#{object_name}"
+                    }, expires)
         end
       end
 

--- a/lib/fog/google/requests/storage_json/get_object_url.rb
+++ b/lib/fog/google/requests/storage_json/get_object_url.rb
@@ -3,18 +3,7 @@ module Fog
     class GoogleJSON
       class Real
         # Get an expiring object url from Google Storage
-        #
-        # ==== Parameters
-        # * bucket_name<~String> - Name of bucket containing object
-        # * object_name<~String> - Name of object to get expiring url for
-        # * expires<~Time> - An expiry time for this url
-        #
-        # ==== Returns
-        # * response<~Excon::Response>:
-        #   * body<~String> - url for object
-        #
-        # ==== See Also
-        # http://docs.amazonwebservices.com/AmazonS3/latest/dev/S3_QSAuth.html
+        # Deprecated, redirects to get_object_https_url.rb
 
         def get_object_url(bucket_name, object_name, expires)
           Fog::Logger.deprecation("Fog::Storage::Google => ##{get_object_url} is deprecated, use ##{get_object_https_url} instead[/] [light_black](#{caller.first})")

--- a/lib/fog/google/requests/storage_json/put_object_url.rb
+++ b/lib/fog/google/requests/storage_json/put_object_url.rb
@@ -13,37 +13,28 @@ module Fog
         # * response<~Excon::Response>:
         #   * body<~String> - url for object
         #
-        def put_object_url(bucket_name, object_name, _headers = {})
+        def put_object_url(bucket_name, object_name, headers = {})
           raise ArgumentError.new("bucket_name is required") unless bucket_name
           raise ArgumentError.new("object_name is required") unless object_name
-
-          api_method = @storage_json.objects.insert
-          parameters = {
-            "uploadType" => "resumable",
-            "bucket" => bucket_name,
-            "name" => object_name
-          }
-
-          request(api_method, parameters)
-          # https_url({
-          #             :headers  => headers,
-          #             :host     => @host,
-          #             :method   => "PUT",
-          #             :path     => "#{bucket_name}/#{object_name}"
-          #           }, expires)
+          https_url({
+                      :headers  => headers,
+                      :host     => @host,
+                      :method   => "PUT",
+                      :path     => "#{bucket_name}/#{object_name}"
+                    }, expires)
         end
       end
 
       class Mock
         def put_object_url(bucket_name, object_name, expires, headers = {})
-          # raise ArgumentError.new("bucket_name is required") unless bucket_name
-          # raise ArgumentError.new("object_name is required") unless object_name
-          # https_url({
-          #             :headers  => headers,
-          #             :host     => @host,
-          #             :method   => "PUT",
-          #             :path     => "#{bucket_name}/#{object_name}"
-          #           }, expires)
+          raise ArgumentError.new("bucket_name is required") unless bucket_name
+          raise ArgumentError.new("object_name is required") unless object_name
+          https_url({
+                      :headers  => headers,
+                      :host     => @host,
+                      :method   => "PUT",
+                      :path     => "#{bucket_name}/#{object_name}"
+                    }, expires)
         end
       end
     end

--- a/lib/fog/google/storage_json.rb
+++ b/lib/fog/google/storage_json.rb
@@ -32,7 +32,7 @@ module Fog
       request :get_object
       request :get_object_acl
       # request :get_object_torrent
-      # request :get_object_http_url
+      request :get_object_http_url
       request :get_object_https_url
       request :get_object_url
       # request :get_service
@@ -43,15 +43,48 @@ module Fog
       request :put_object_acl
       request :put_object_url
 
+      module Utils
+        def http_url(params, expires)
+          "http://" << host_path_query(params, expires)
+        end
+
+        def https_url(params, expires)
+          "https://" << host_path_query(params, expires)
+        end
+
+        def url(params, expires)
+          Fog::Logger.deprecation("Fog::Storage::Google => #url is deprecated, use #https_url instead [light_black](#{caller.first})[/]")
+          https_url(params, expires)
+        end
+
+        private
+
+        def host_path_query(params, expires)
+          params[:headers]["Date"] = expires.to_i
+          params[:path] = CGI.escape(params[:path]).gsub("%2F", "/")
+          query = [params[:query]].compact
+          query << "GoogleAccessId=#{@client.authorization.issuer}"
+          query << "Signature=#{CGI.escape(signature(params))}"
+          query << "Expires=#{params[:headers]['Date']}"
+          "#{params[:host]}/#{params[:path]}?#{query.join('&')}"
+        end
+      end
+
       class Mock
+        include Utils
         include Fog::Google::Shared
 
         def initialize(options)
           shared_initialize(options[:google_project], GOOGLE_STORAGE_JSON_API_VERSION, GOOGLE_STORAGE_JSON_BASE_URL)
         end
+
+        def signature(_params)
+          "foo"
+        end
       end
 
       class Real
+        include Utils
         include Fog::Google::Shared
 
         attr_accessor :client
@@ -60,9 +93,52 @@ module Fog
         def initialize(options)
           shared_initialize(options[:google_project], GOOGLE_STORAGE_JSON_API_VERSION, GOOGLE_STORAGE_JSON_BASE_URL)
           options.merge!(:google_api_scope_url => GOOGLE_STORAGE_JSON_API_SCOPE_URLS.join(" "))
+          @host = options[:host] || "storage.googleapis.com"
 
           @client = initialize_google_client(options)
           @storage_json = @client.discovered_api("storage", api_version)
+        end
+
+        def signature(params)
+          string_to_sign =
+<<-DATA
+#{params[:method]}
+#{params[:headers]['Content-MD5']}
+#{params[:headers]['Content-Type']}
+#{params[:headers]['Date']}
+DATA
+
+          google_headers = {}
+          canonical_google_headers = ""
+          for key, value in params[:headers]
+            google_headers[key] = value if key[0..6] == "x-goog-"
+          end
+
+          google_headers = google_headers.sort { |x, y| x[0] <=> y[0] }
+          for key, value in google_headers
+            canonical_google_headers << "#{key}:#{value}\n"
+          end
+          string_to_sign << "#{canonical_google_headers}"
+
+          canonical_resource = "/"
+          if subdomain = params.delete(:subdomain)
+            canonical_resource << "#{CGI.escape(subdomain).downcase}/"
+          end
+          canonical_resource << "#{params[:path]}"
+          canonical_resource << "?"
+          for key in (params[:query] || {}).keys
+            if %w(acl cors location logging requestPayment torrent versions versioning).include?(key)
+              canonical_resource << "#{key}&"
+            end
+          end
+          canonical_resource.chop!
+          string_to_sign << "#{canonical_resource}"
+
+          key = OpenSSL::PKey::RSA.new(@client.authorization.signing_key)
+          digest = OpenSSL::Digest::SHA256.new
+          signed_string = key.sign(digest, string_to_sign)
+
+          Base64.encode64(signed_string).chomp!
         end
       end
     end


### PR DESCRIPTION
Bringing back URL signatures allows us to create expiring https and http URLs as well as PUT object functionality. Great news!
